### PR TITLE
Update WcRestrictContentOpenTagModule.php

### DIFF
--- a/src/WcRestrictContentOpenTagModule.php
+++ b/src/WcRestrictContentOpenTagModule.php
@@ -123,7 +123,7 @@ class WcRestrictContentOpenTagModule extends ET_Builder_Module
         $this->field_defaults = $defaults;
 
 
-        $this->options_toggles = array(
+        $this->settings_modal_toggles = array(
             'general' => array(
                     'settings' => array(
                         'toggles_disabled' => true,


### PR DESCRIPTION
Hi, I haven't tested this change properly but I just want to notify the following notifications in the debug.log.

.../builder/class-et-builder-element.php:3590 ET_Builder_Element::render(): You're Doing It Wrong!
DF\DF_RESTRICT_CONTENT\WcRestrictContentOpenTagModule::shortcode_callback() is deprecated. Use
DF\DF_RESTRICT_CONTENT\WcRestrictContentOpenTagModule::render() instead.

.../src/WcRestrictContentOpenTagModule.php:126 DF\DF_RESTRICT_CONTENT\WcRestrictContentOpenTagModule::init():  DF\DF_RESTRICT_CONTENT\WcRestrictContentOpenTagModule::$options_toggles is deprecated.  Use DF\DF_RESTRICT_CONTENT\WcRestrictContentOpenTagModule::$settings_modal_toggles instead.